### PR TITLE
fix maven-surefire-plugin 2.18.1 -> 3.0.0-M1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -369,7 +369,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.18.1</version>
+        <version>3.0.0-M1</version>
         <configuration>
           <useFile>false</useFile>
           <disableXmlReport>true</disableXmlReport>


### PR DESCRIPTION
see Issue https://github.com/biggis-project/biggis-landuse/issues/21

fix build issue with maven-surefire-plugin

**2.18.1** -> **3.0.0-M1** (update 2.x -> 3.x)